### PR TITLE
Do not break URL parsing on special characters.

### DIFF
--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -18,8 +18,7 @@ fn parse_urls(body: &str) -> Vec<(&str, bool)>
         }
 
         let url_text = &remaining[start..];
-        let end = url_text.find(|c: char| c.is_whitespace() || c == '>' || c == ')' || c == ']')
-            .unwrap_or(url_text.len());
+        let end = url_text.find(|c: char| c.is_whitespace()).unwrap_or(url_text.len());
 
         parts.push((&remaining[start..start + end], true));
         remaining = &remaining[start + end..];


### PR DESCRIPTION
Previously >, ] and ) stopped link parsing which broke links with these characters.