### PR TITLE
Add Alt+Up/Down to cycle the active sidebar selection.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,8 @@ pub enum Message
     Ignore,
     TabPressed,
     ShiftTabPressed,
+    NextSelection,
+    PrevSelection,
     JidInputChanged(String),
     PasswordInputChanged(String),
     RememberMeToggled(bool),
@@ -202,6 +204,45 @@ impl Snack
         }
     }
 
+    // Step through the flat list of sidebar entries (rooms first, then chats),
+    // wrapping at either end. Returns the Task that performs the selection, or
+    // None when there is nothing to select.
+    fn step_selection(&self, forward: bool) -> Option<Task<Message>>
+    {
+        if self.state != AppState::Connected
+        {
+            return None;
+        }
+
+        let total = self.rooms.len() + self.chats.len();
+        if total == 0
+        {
+            return None;
+        }
+
+        let next_idx = match self.active
+        {
+            None => if forward { 0 } else { total - 1 },
+            Some(Selection::Room(i)) =>
+            {
+                let cur = i;
+                if forward { (cur + 1) % total } else { (cur + total - 1) % total }
+            }
+            Some(Selection::Chat(i)) =>
+            {
+                let cur = self.rooms.len() + i;
+                if forward { (cur + 1) % total } else { (cur + total - 1) % total }
+            }
+        };
+
+        if next_idx < self.rooms.len()
+        {
+            return Some(Task::done(Message::SelectRoom(next_idx)));
+        }
+
+        return Some(Task::done(Message::SelectChat(next_idx - self.rooms.len())));
+    }
+
     fn update(&mut self, message: Message) -> Task<Message>
     {
         match message
@@ -214,6 +255,20 @@ impl Snack
             Message::ShiftTabPressed =>
             {
                 return iced::widget::operation::focus_previous();
+            }
+            Message::NextSelection =>
+            {
+                if let Some(task) = self.step_selection(true)
+                {
+                    return task;
+                }
+            }
+            Message::PrevSelection =>
+            {
+                if let Some(task) = self.step_selection(false)
+                {
+                    return task;
+                }
             }
             Message::JidInputChanged(value) =>
             {
@@ -983,6 +1038,18 @@ impl Snack
                         return Message::ShiftTabPressed;
                     }
                     return Message::TabPressed;
+                }
+
+                if modifiers.alt() && !modifiers.shift() && !modifiers.control() && !modifiers.command()
+                {
+                    if key == iced::keyboard::Key::Named(iced::keyboard::key::Named::ArrowUp)
+                    {
+                        return Message::PrevSelection;
+                    }
+                    if key == iced::keyboard::Key::Named(iced::keyboard::key::Named::ArrowDown)
+                    {
+                        return Message::NextSelection;
+                    }
                 }
             }
 


### PR DESCRIPTION
Alt+Down moves to the next entry in the sidebar (rooms in order, then chats), Alt+Up moves to the previous, wrapping around at both ends. The shortcut is only active while connected.