### PR TITLE
Remove room locally when leaving instead of awaiting server

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -883,7 +883,14 @@ impl Snack
                         }
                     }
 
-                    // Room removal is driven by XmppEvent::RoomLeft.
+                    // Remove the room immediately rather than waiting for the
+                    // server to confirm via XmppEvent::RoomLeft — if the
+                    // connection is dropped or the command never reaches the
+                    // server, the user is otherwise stuck with a phantom room.
+                    // The RoomLeft handler becomes a no-op if the room is
+                    // already gone.
+                    self.rooms.remove(index);
+                    self.active = None;
                 }
             }
             Message::CloseChat =>


### PR DESCRIPTION
## Summary

`Message::LeaveRoom` currently sends a `LeaveRoom` command to the XMPP thread and relies on the server's `XmppEvent::RoomLeft` echo to actually drop the room from the sidebar. If that confirmation never arrives, the user is stuck with a phantom row.

## Failure modes that produce no `RoomLeft`

1. `try_send` returns `Err` because the 100-slot command channel is full (e.g. user sent many messages over a slow link, then clicks Leave). The error is `let _ =`'d, so the leave is silently dropped.
2. `try_send` succeeds, but `client.leave_room(...).await` in `src/xmpp/mod.rs` fails — the error is logged and discarded, no event surfaces to the UI.
3. The connection drops between `try_send` and the actual send.

In all three, the local `saved_config.rooms` is already updated (config-on-disk says "left") while `self.rooms` still has the row.

## Fix

Remove the room from `self.rooms` and clear `self.active` immediately, just like `CloseChat` does for direct-message chats. The existing `XmppEvent::RoomLeft` handler uses `position()` and is a no-op when the room is already gone, so a later confirmation from the server doesn't double-remove anything.

## Test plan

- [ ] Join a room, click **Leave** — room disappears from sidebar, `saved_config.rooms` updated.
- [ ] Join two rooms (A active, B inactive), leave A — A disappears, B remains, active selection clears.
- [ ] Simulate slow/dropped connection (e.g. block the XMPP port), click Leave — room still disappears locally instead of getting stuck.