### PR TITLE
Add multiline support to the message input.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,5 @@
 use iced::{ Task, Theme };
-use iced::widget::Id;
+use iced::widget::{ text_editor, Id };
 
 use crate::message::Message;
 use crate::{ room, storage, xmpp };
@@ -64,7 +64,7 @@ pub struct Snack
     pub(crate) rooms: Vec<room::Room>,
     pub(crate) chats: Vec<room::chat::Chat>,
     pub(crate) active: Option<Selection>,
-    pub(crate) message_input: String,
+    pub(crate) message_input: text_editor::Content,
     pub(crate) show_join_panel: bool,
     pub(crate) joining_room: Option<String>,
     pub(crate) join_error: Option<String>,
@@ -97,7 +97,7 @@ impl Snack
             rooms: Vec::new(),
             chats: Vec::new(),
             active: None,
-            message_input: String::new(),
+            message_input: text_editor::Content::new(),
             show_join_panel: false,
             joining_room: None,
             join_error: None,

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,3 +1,5 @@
+use iced::widget::text_editor;
+
 use crate::xmpp;
 
 #[derive(Debug, Clone)]
@@ -20,7 +22,7 @@ pub enum Message
     SelectRoom(usize),
     SelectChat(usize),
     StartChat(String),
-    InputChanged(String),
+    InputAction(text_editor::Action),
     SendMessage,
     ShowJoinPanel,
     HideJoinPanel,

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -1,5 +1,6 @@
 use iced::{ Color, Element, Fill, Length };
-use iced::widget::{ button, column, container, rich_text, row, scrollable, span, text, text_input, Id };
+use iced::keyboard;
+use iced::widget::{ button, column, container, rich_text, row, scrollable, span, text, text_editor, Id };
 
 use crate::{ Message, Selection, Snack, MESSAGE_SCROLL_ID, MESSAGE_INPUT_ID };
 use crate::room::message::{ Message as RoomMessage, EventKind };
@@ -204,18 +205,37 @@ fn render_messages<'a>(
 
 fn input_row(state: &Snack) -> Element<'_, Message>
 {
-    let input = text_input("Type a message...", &state.message_input)
+    let input = text_editor(&state.message_input)
         .id(Id::new(MESSAGE_INPUT_ID))
-        .on_input(Message::InputChanged)
-        .on_submit(Message::SendMessage)
+        .placeholder("Type a message...")
+        .on_action(Message::InputAction)
+        .key_binding(|press|
+        {
+            // Plain Enter sends the message. Alt+Enter (and Shift+Enter as a
+            // common alternative) inserts a newline instead.
+            if matches!(press.key, keyboard::Key::Named(keyboard::key::Named::Enter))
+            {
+                if press.modifiers.alt() || press.modifiers.shift()
+                {
+                    return Some(text_editor::Binding::Enter);
+                }
+                return Some(text_editor::Binding::Custom(Message::SendMessage));
+            }
+            return text_editor::Binding::from_key_press(press);
+        })
         .padding(10)
-        .width(Fill);
+        .height(Length::Shrink)
+        .max_height(160.0);
 
     let send_btn = button(text("Send").size(14))
         .on_press(Message::SendMessage)
         .padding(10);
 
-    return row![input, send_btn].spacing(8).width(Fill).into();
+    return row![input, send_btn]
+        .align_y(iced::Alignment::End)
+        .spacing(8)
+        .width(Fill)
+        .into();
 }
 
 pub fn view(state: &Snack) -> Element<'_, Message>

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -221,6 +221,21 @@ fn input_row(state: &Snack) -> Element<'_, Message>
                 }
                 return Some(text_editor::Binding::Custom(Message::SendMessage));
             }
+            // Alt+Up/Down navigates between selections. The editor would
+            // otherwise capture the arrow keys to move the cursor between
+            // lines, so the global keyboard subscription never sees them.
+            if press.modifiers.alt() && !press.modifiers.shift()
+                && !press.modifiers.control() && !press.modifiers.command()
+            {
+                if matches!(press.key, keyboard::Key::Named(keyboard::key::Named::ArrowUp))
+                {
+                    return Some(text_editor::Binding::Custom(Message::PrevSelection));
+                }
+                if matches!(press.key, keyboard::Key::Named(keyboard::key::Named::ArrowDown))
+                {
+                    return Some(text_editor::Binding::Custom(Message::NextSelection));
+                }
+            }
             return text_editor::Binding::from_key_press(press);
         })
         .padding(10)

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,5 +1,5 @@
 use iced::Task;
-use iced::widget::Id;
+use iced::widget::{ text_editor, Id };
 use log::{ error, warn };
 
 use crate::app::{
@@ -107,9 +107,10 @@ impl Snack
         };
 
         // Resume an in-progress cycle only if the input wasn't edited in between.
+        let current_input = self.message_input.text();
         let mut state = self.nick_complete
             .take()
-            .filter(|s| s.last_output == self.message_input);
+            .filter(|s| s.last_output == current_input);
 
         if let Some(ref mut s) = state
         {
@@ -126,7 +127,7 @@ impl Snack
         {
             // Start a fresh cycle: find the partial word at the end of the input
             // (whitespace-delimited) and gather all matching nicks alphabetically.
-            let input = &self.message_input;
+            let input = &current_input;
             let prefix_start = input
                 .char_indices()
                 .rev()
@@ -166,13 +167,16 @@ impl Snack
         let mut state = state.expect("state populated above");
         let nick = &state.matches[state.index];
         let suffix = if state.prefix_start == 0 { ": " } else { " " };
-        let new_input = format!("{}{}{}", &self.message_input[..state.prefix_start], nick, suffix);
+        let new_input = format!("{}{}{}", &current_input[..state.prefix_start], nick, suffix);
 
-        self.message_input = new_input.clone();
+        self.message_input = text_editor::Content::with_text(&new_input);
+        self.message_input.perform(text_editor::Action::Move(
+            iced::widget::text_editor::Motion::DocumentEnd,
+        ));
         state.last_output = new_input;
         self.nick_complete = Some(state);
 
-        return iced::widget::operation::move_cursor_to_end(Id::new(MESSAGE_INPUT_ID));
+        return iced::widget::operation::focus(Id::new(MESSAGE_INPUT_ID));
     }
 
     pub(crate) fn update(&mut self, message: Message) -> Task<Message>
@@ -373,7 +377,7 @@ impl Snack
                         self.rooms.clear();
                         self.chats.clear();
                         self.active = None;
-                        self.message_input.clear();
+                        self.message_input = text_editor::Content::new();
                         self.show_join_panel = false;
                         self.joining_room = None;
                         self.join_error = None;
@@ -684,7 +688,7 @@ impl Snack
                 self.rooms.clear();
                 self.chats.clear();
                 self.active = None;
-                self.message_input.clear();
+                self.message_input = text_editor::Content::new();
                 self.show_join_panel = false;
                 self.joining_room = None;
                 self.join_error = None;
@@ -759,17 +763,22 @@ impl Snack
 
                 return Task::done(Message::SelectChat(idx));
             }
-            Message::InputChanged(value) =>
+            Message::InputAction(action) =>
             {
-                if self.nick_complete.as_ref().is_some_and(|s| s.last_output != value)
+                let is_edit = action.is_edit();
+                self.message_input.perform(action);
+                if is_edit
                 {
-                    self.nick_complete = None;
+                    let text = self.message_input.text();
+                    if self.nick_complete.as_ref().is_some_and(|s| s.last_output != text)
+                    {
+                        self.nick_complete = None;
+                    }
                 }
-                self.message_input = value;
             }
             Message::SendMessage =>
             {
-                let body = self.message_input.trim().to_string();
+                let body = self.message_input.text().trim().to_string();
 
                 if body.is_empty()
                 {
@@ -793,7 +802,7 @@ impl Snack
                             }
                         }
 
-                        self.message_input.clear();
+                        self.message_input = text_editor::Content::new();
                         self.nick_complete = None;
 
                         return Task::batch([snap_to_bottom(), focus_input()]);
@@ -838,7 +847,7 @@ impl Snack
                             }
                         }
 
-                        self.message_input.clear();
+                        self.message_input = text_editor::Content::new();
                         self.nick_complete = None;
 
                         return Task::batch([snap_to_bottom(), focus_input()]);


### PR DESCRIPTION
Use iced's text_editor instead of text_input so the input can grow across multiple lines. Plain Enter still sends; Alt+Enter (or Shift+Enter) inserts a newline.